### PR TITLE
geomloss import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.9"
 dependencies = [
     "anndata>=0.9",
     "h5py>=3.8",
+    "geomloss>=0.2.6",
     "numpy>=1.22",
     "pandas>=1.5",
     "psutil>=5.9",

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ include_package_data = True
 install_requires =
     anndata>=0.9
     h5py>=3.8
+    geomloss>=0.2.6
     numpy>=1.22
     pandas>=1.5
     psutil>=5.9


### PR DESCRIPTION
`stack-train --help` fails like 
```
Traceback (most recent call last):
  File "/home/dhruvgautam/stack/src/stack/cli/launch_training.py", line 19, in <module>
    from stack.training.datamodule import MultiDatasetDataModule
  File "/home/dhruvgautam/stack/src/stack/training/__init__.py", line 3, in <module>
    from .lightning import LegacyLightningGeneModel, LightningGeneModel
  File "/home/dhruvgautam/stack/src/stack/training/lightning.py", line 9, in <module>
    from ..model import StateICLModel, scShiftAttentionModel
  File "/home/dhruvgautam/stack/src/stack/model.py", line 5, in <module>
    from .models.core import StateICLModel, scShiftAttentionModel
  File "/home/dhruvgautam/stack/src/stack/models/__init__.py", line 4, in <module>
    from .finetune import ICL_FinetunedModel
  File "/home/dhruvgautam/stack/src/stack/models/finetune/__init__.py", line 3, in <module>
    from .model import ICL_FinetunedModel
  File "/home/dhruvgautam/stack/src/stack/models/finetune/model.py", line 10, in <module>
    from .mixins import FinetuneInitializationMixin, FinetuneLossMixin
  File "/home/dhruvgautam/stack/src/stack/models/finetune/mixins.py", line 10, in <module>
    from geomloss import SamplesLoss
ModuleNotFoundError: No module named 'geomloss'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dhruvgautam/miniconda/envs/sta/bin/stack-train", line 4, in <module>
    from stack.cli.launch_training import main
  File "/home/dhruvgautam/stack/src/stack/cli/launch_training.py", line 23, in <module>
    from cli_utils import apply_config_from_file, filter_unused_arguments  # type: ignore
ModuleNotFoundError: No module named 'cli_utils'
```

due to import