### PR TITLE
Fix h5py compatibility for dense matrix reading in datasets

### DIFF
--- a/src/stack/data/finetuning/datasets.py
+++ b/src/stack/data/finetuning/datasets.py
@@ -380,7 +380,7 @@ class MultiDatasetMetadataCache:
                             X_group = f["X"]
                         
                         # Check if sparse
-                        is_sparse = not hasattr(X_group, 'shape') or ('data' in X_group and 'indices' in X_group)
+                        is_sparse = isinstance(X_group, h5py.Group) and 'data' in X_group and 'indices' in X_group
                         
                         # Store file information
                         file_info = {
@@ -708,7 +708,7 @@ class MultiDatasetMetadataCache:
             else:
                 # Dense matrix: direct slicing
                 log.debug(f"Using dense matrix reading for {len(absolute_indices_to_load)} rows")
-                expr_subset = X_group[np.ix_(absolute_indices_to_load, source_indices_in_file)]
+                expr_subset = X_group[sorted(absolute_indices_to_load)][:, source_indices_in_file]
                 mapped_matrix[:, target_indices_in_result] = expr_subset.astype(np.float32)
 
         except Exception as e:
@@ -1609,7 +1609,7 @@ class TestSamplerDataset(Dataset):
             'use_raw': use_raw,
             'gene_mapping': gene_mapping,
             'organism_mask': human_mask,
-            'is_sparse': not hasattr(X_group, 'shape') or ('data' in X_group and 'indices' in X_group),
+            'is_sparse': isinstance(X_group, h5py.Group) and 'data' in X_group and 'indices' in X_group,
             'found_genes': found_genes
         }
         
@@ -1858,7 +1858,7 @@ class TestSamplerDataset(Dataset):
             else:
                 # Dense matrix: direct slicing
                 log.debug(f"Using dense matrix reading for {len(absolute_indices_to_load)} rows")
-                expr_subset = X_group[np.ix_(absolute_indices_to_load, source_indices_in_file)]
+                expr_subset = X_group[sorted(absolute_indices_to_load)][:, source_indices_in_file]
                 mapped_matrix[:, target_indices_in_result] = expr_subset.astype(np.float32)
 
         except Exception as e:

--- a/src/stack/data/training/datasets.py
+++ b/src/stack/data/training/datasets.py
@@ -199,7 +199,7 @@ class SimplifiedDatasetCache:
                         else:
                             X_group = f["X"]
                         
-                        is_sparse = not hasattr(X_group, 'shape') or ('data' in X_group and 'indices' in X_group)
+                        is_sparse = isinstance(X_group, h5py.Group) and 'data' in X_group and 'indices' in X_group
                         
                         # Store file information
                         file_info = {
@@ -435,7 +435,7 @@ class SimplifiedDatasetCache:
             else:
                 # Dense matrix: direct slicing
                 log.debug(f"Using dense matrix reading for {len(absolute_indices_to_load)} rows")
-                expr_subset = X_group[np.ix_(absolute_indices_to_load, source_indices_in_file)]
+                expr_subset = X_group[sorted(absolute_indices_to_load)][:, source_indices_in_file]
                 mapped_matrix[:, target_indices_in_result] = expr_subset.astype(np.float32)
 
         except Exception as e:
@@ -855,7 +855,7 @@ class TestSamplerDataset(Dataset):
                 'use_raw': use_raw,
                 'gene_mapping': self.gene_mapping,
                 'organism_mask': self.human_mask,
-                'is_sparse': not hasattr(X_group, 'shape') or ('data' in X_group and 'indices' in X_group),
+                'is_sparse': isinstance(X_group, h5py.Group) and 'data' in X_group and 'indices' in X_group,
                 'found_genes': found_genes
             }
             
@@ -1171,7 +1171,7 @@ class TestSamplerDataset(Dataset):
             
             else:
                 # Dense matrix: direct slicing
-                expr_subset = X_group[np.ix_(absolute_indices_to_load, source_indices_in_file)]
+                expr_subset = X_group[sorted(absolute_indices_to_load)][:, source_indices_in_file]
                 mapped_matrix[:, target_indices_in_result] = expr_subset.astype(np.float32)
             
         except Exception as e:


### PR DESCRIPTION
Two issues when reading dense (non-sparse) h5ad files:

1. Sparse detection used `'data' in X_group` which, when X_group is a dense h5py.Dataset, tests membership in the array data rather than checking for group keys. This returns a boolean array, raising "ValueError: truth value of an array is ambiguous". Fixed by checking `isinstance(X_group, h5py.Group)` first.

2. Dense matrix slicing used `np.ix_()` to build a 2D fancy index, but h5py only supports 1D fancy indexing on datasets. Fixed by using sequential row then column slicing.

Affects both training and finetuning dataset loaders.